### PR TITLE
Correction des droits sur le fichier de configuration docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,7 @@ FROM jenkins/jenkins:lts-alpine
 USER root
 RUN addgroup -g 994 docker
 RUN apk --no-cache add shadow && usermod -aG 994 jenkins
-COPY config.json /var/jenkins_home/.docker/config.json
-RUN chown jenkins:jenkins /var/jenkins_home/.docker/config.json
+COPY --chown=jenkins:jenkins config.json /var/jenkins_home/.docker/config.json
 RUN curl https://get.docker.com/builds/Linux/x86_64/docker-latest.tgz | tar xvz -C /tmp/ && \
     mv /tmp/docker/docker /usr/bin/docker
 USER jenkins


### PR DESCRIPTION
J'ai testé : 
[root@ate-julien-02 docker-training-ci-jenkins]# docker run -ti gormux/jentest ls -la /var/jenkins_home/.docker
total 4
drwxr-sr-x 2 jenkins jenkins  25 Jun  4 14:56 .
drwxr-sr-x 3 jenkins jenkins  52 Jun  4 14:56 ..
-rw-r--r-- 1 jenkins jenkins 147 Jun  4 13:37 config.json
[root@ate-julien-02 docker-training-ci-jenkins]# docker run -ti gormux/jentest ls -la /var/jenkins_home/
